### PR TITLE
Push to Release Workflow Added

### DIFF
--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -1,10 +1,36 @@
-name: Push to Release Branch 
+name: Push to Release Branch Sync
 
 on:
   workflow_dispatch:
     inputs:
+      org:
+        description: 'Select Organization'
+        required: true
+        type: choice
+        options:
+          - 'opendatahub.io'
+          - 'red-hat-data-services'
+      sync_repo:
+        description: 'Select Repository'
+        required: true
+        type: choice
+        options:
+          - 'modelmesh'
+          - 'caikit-tgis-serving'
+          - 'openvino'
+          - 'vllm'
+          - 'caikit-nlp'
+          - 'caikit'
+          - 'odh-model-controller'
+          - 'caikit-tgis-backend'
+          - 'caikit-nlp-client'
+          - 'model-registry'
+      main_branch:
+        description: 'Main branch to pull from'
+        default: 'main'
+        required: true
       release_branch:
-        description: 'Branch to push to'
+        description: 'Branch to push to [release branch]'
         required: true
 
 env:
@@ -14,32 +40,35 @@ jobs:
   push-release-branch:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
 
-    - name: Set up Git
-      run: |
-        git config --global user.name '${{ github.actor }}'
-        git config --global user.email '${{ github.actor }}@users.noreply.github.com'
-    - name: Fetch all branches
-      run: git fetch --all
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
 
-    - name: Check if branch exists
-      id: check_branch
-      run: |
-        if git show-ref --verify --quiet refs/heads/${{ github.event.inputs.release_branch }}; then
-          echo "branch_exists=true" >> $GITHUB_ENV
-        else
-          echo "branch_exists=false" >> $GITHUB_ENV
-        fi
-    - name: Create or checkout branch
-      run: |
-        if [ "$branch_exists" = "true" ]; then
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            repository: ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }}
+            token: ${{ secrets.ACTIONS_PAT }}
+
+      
+      - name: Print current repository
+        run: git remote -v
+
+      - name: Fetch all branches
+        run: git fetch --all
+
+      - name: Checkout release branch
+        run: |
           git checkout ${{ github.event.inputs.release_branch }}
-        else
-          git checkout -b ${{ github.event.inputs.release_branch }}
-        fi
-    - name: Push to release branch  
-      run: |
-        git remote set-url origin https://x-access-token:${{ secrets.ACTIONS_PAT }}@github.com/${{ github.repository }}.git
-        git push origin ${{ github.event.inputs.release_branch }}
+
+      - name: Rebase main onto release branch
+        run: |
+            git rebase origin/${{ github.event.inputs.main_branch }} 
+
+      - name: Push changes
+        run: |
+          git push origin ${{ github.event.inputs.release_branch }} --force
+
+             

--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -1,4 +1,4 @@
-name: Push to Release Branch Sync
+name: Push Main to Release Branch Sync
 
 on:
   workflow_dispatch:

--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -1,0 +1,45 @@
+name: Push to Release Branch 
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'Branch to push to'
+        required: true
+
+env:
+  ACTIONS_PAT: ${{ secrets.ACTIONS_PAT }}
+
+jobs:
+  push-release-branch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Git
+      run: |
+        git config --global user.name '${{ github.actor }}'
+        git config --global user.email '${{ github.actor }}@users.noreply.github.com'
+    - name: Fetch all branches
+      run: git fetch --all
+
+    - name: Check if branch exists
+      id: check_branch
+      run: |
+        if git show-ref --verify --quiet refs/heads/${{ github.event.inputs.release_branch }}; then
+          echo "branch_exists=true" >> $GITHUB_ENV
+        else
+          echo "branch_exists=false" >> $GITHUB_ENV
+        fi
+    - name: Create or checkout branch
+      run: |
+        if [ "$branch_exists" = "true" ]; then
+          git checkout ${{ github.event.inputs.release_branch }}
+        else
+          git checkout -b ${{ github.event.inputs.release_branch }}
+        fi
+    - name: Push to release branch  
+      run: |
+        git remote set-url origin https://x-access-token:${{ secrets.ACTIONS_PAT }}@github.com/${{ github.repository }}.git
+        git push origin ${{ github.event.inputs.release_branch }}

--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -37,10 +37,7 @@ env:
   ACTIONS_PAT: ${{ secrets.ACTIONS_PAT }}
 
 permissions:
-  # Need `contents: read` to checkout the repository
-  # Need `contents: write` to merge branches
   contents: write
-  
 
 jobs:
   push-release-branch:
@@ -51,7 +48,6 @@ jobs:
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -59,26 +55,34 @@ jobs:
             token: ${{ secrets.ACTIONS_PAT }}
             fetch-depth: 0
 
-      
       - name: Print current repository
         run: git remote -v
 
       - name: Fetch all branches
         run: git fetch --all
 
-      - name: Check out release branch
+      - name: Check out and create sync-release branch
         run: |
           git checkout ${{ github.event.inputs.release_branch }}
-          git fetch origin
-
-
-      - name: Push changes to release branch & Create a PR
+          git pull origin ${{ github.event.inputs.release_branch }}
+          git checkout -b sync-new-release
+      - name: Sync
+        uses: TobKed/github-forks-sync-action@master
+        with:
+          github_token: ${{ secrets.ACTIONS_PAT }}
+          upstream_repository: ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }}
+          target_repository: ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }}
+          upstream_branch: ${{ github.event.inputs.main_branch }}
+          target_branch: sync-new-release
+          force: false
+          tags: false
+        
+      - name: Create a PR
         run: |
-            git push origin ${{ github.event.inputs.release_branch }}
-            gh pr create --repo ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }} \
-            --head ${{ github.event.inputs.release_branch }} \
-            --base ${{ github.event.inputs.main_branch }} \
-            --title "Sync changes from ${{ github.event.inputs.main_branch }} to ${{ github.event.inputs.release_branch }}" \
-            --body "This is an automated PR created by the GitHub Action to sync changes from the main branch to the release branch."
+              gh pr create --repo ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }} \
+              --head sync-new-release \
+              --base ${{ github.event.inputs.release_branch }} \
+              --title "Sync changes from ${{ github.event.inputs.main_branch }} to ${{ github.event.inputs.release_branch }}" \
+              --body "This is an automated PR created by the GitHub Action to sync changes from the main branch to the release branch."
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}            
+            GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}

--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -1,4 +1,4 @@
-name: Push Main to Release Branch Sync
+name: Main branch to Release Branch Sync PR
 
 on:
   workflow_dispatch:
@@ -37,6 +37,8 @@ env:
   ACTIONS_PAT: ${{ secrets.ACTIONS_PAT }}
 
 permissions:
+  # Need `contents: read` to checkout the repository
+  # Need `contents: write` to merge branches
   contents: write
   
 
@@ -64,30 +66,22 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
-
-      - name: Merge Master to Production branch
-        uses: devvspaces/merge-branches@v1
-        with:
-              token: ${{ secrets.ACTIONS_PAT }}
-              from_branch: ${{ github.event.inputs.main_branch }}
-              to_branch: ${{ github.event.inputs.release_branch }}
-      
-      - name: Create release-v2 branch if not exists
+      - name: Check out release branch
         run: |
-            git push -u origin ${{ github.event.inputs.release_branch }}  # Push release-v2 branch to remote
+          git checkout ${{ github.event.inputs.release_branch }}
+          git fetch origin
 
-    
+      - name: Merge main into release
+        run: |
+          git merge origin/main
+
       - name: Push changes to release branch & Create a PR
         run: |
-          git log -n 1 --pretty=format:"%H - %s"
-          git push -f origin ${{ github.event.inputs.release_branch }}
-          gh pr create --repo ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }} \
+            git push origin ${{ github.event.inputs.release_branch }}
+            gh pr create --repo ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }} \
             --head ${{ github.event.inputs.release_branch }} \
             --base ${{ github.event.inputs.main_branch }} \
             --title "Sync changes from ${{ github.event.inputs.main_branch }} to ${{ github.event.inputs.release_branch }}" \
             --body "This is an automated PR created by the GitHub Action to sync changes from the main branch to the release branch."
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}         
-
-
-             
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}            

--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -36,6 +36,10 @@ on:
 env:
   ACTIONS_PAT: ${{ secrets.ACTIONS_PAT }}
 
+permissions:
+  contents: write
+  
+
 jobs:
   push-release-branch:
     runs-on: ubuntu-latest
@@ -51,6 +55,7 @@ jobs:
         with:
             repository: ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }}
             token: ${{ secrets.ACTIONS_PAT }}
+            fetch-depth: 0
 
       
       - name: Print current repository
@@ -59,16 +64,30 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
-      - name: Checkout release branch
-        run: |
-          git checkout ${{ github.event.inputs.release_branch }}
 
-      - name: Rebase main onto release branch
+      - name: Merge Master to Production branch
+        uses: devvspaces/merge-branches@v1
+        with:
+              token: ${{ secrets.ACTIONS_PAT }}
+              from_branch: ${{ github.event.inputs.main_branch }}
+              to_branch: ${{ github.event.inputs.release_branch }}
+      
+      - name: Create release-v2 branch if not exists
         run: |
-            git rebase origin/${{ github.event.inputs.main_branch }} 
+            git push -u origin ${{ github.event.inputs.release_branch }}  # Push release-v2 branch to remote
 
-      - name: Push changes
+    
+      - name: Push changes to release branch & Create a PR
         run: |
-          git push origin ${{ github.event.inputs.release_branch }} --force
+          git log -n 1 --pretty=format:"%H - %s"
+          git push -f origin ${{ github.event.inputs.release_branch }}
+          gh pr create --repo ${{ github.event.inputs.org }}/${{ github.event.inputs.sync_repo }} \
+            --head ${{ github.event.inputs.release_branch }} \
+            --base ${{ github.event.inputs.main_branch }} \
+            --title "Sync changes from ${{ github.event.inputs.main_branch }} to ${{ github.event.inputs.release_branch }}" \
+            --body "This is an automated PR created by the GitHub Action to sync changes from the main branch to the release branch."
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}         
+
 
              

--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -71,9 +71,6 @@ jobs:
           git checkout ${{ github.event.inputs.release_branch }}
           git fetch origin
 
-      - name: Merge main into release
-        run: |
-          git merge origin/main
 
       - name: Push changes to release branch & Create a PR
         run: |


### PR DESCRIPTION
### Workflow to Push to Release branch
Implemented a GitHub Actions workflow that push code from an upstream/main branch  to a release branch. 

We need a PAT_TOKEN of the repo odh-automation-serving to execute the workflow as normal github token doesn't work here as we are trying to run the workflow from another repository.

Issue : [RHOAIENG-8803](https://issues.redhat.com/browse/RHOAIENG-8803)


