### PR TITLE
Workflow to Pull from Upstream and Cherry-pick Patches

### DIFF
--- a/.github/workflows/pull_upstream_with_cherrypick.yml
+++ b/.github/workflows/pull_upstream_with_cherrypick.yml
@@ -62,12 +62,10 @@ jobs:
         fi
         if [ -n "$upstreamOwner" ] && [[ "${{ github.event.inputs.Pull_and_cherrypick }}" == "Upstream->Midstream(opendatahub-io)" ]]; then
           echo "upstream_org_repo=${{ github.event.inputs.upstream_repo }}"  >> $GITHUB_OUTPUT
-          # echo "target_org_repo=opendatahub-io/$repoName" >> $GITHUB_OUTPUT
-          echo "target_org_repo=rpancham/$repoName" >> $GITHUB_OUTPUT
+          echo "target_org_repo=opendatahub-io/$repoName" >> $GITHUB_OUTPUT 
         else
           echo "upstream_org_repo=opendatahub-io/$repoName"  >> $GITHUB_OUTPUT
-          # echo "target_org_repo=red-hat-data-services/$repoName" >> $GITHUB_OUTPUT
-          echo "target_org_repo=rpancham/$repoName" >> $GITHUB_OUTPUT
+          echo "target_org_repo=red-hat-data-services/$repoName" >> $GITHUB_OUTPUT  
         fi
     - name: Configure Git
       run: |
@@ -78,7 +76,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ${{ steps.set-repo.outputs.target_org_repo }}
-        token: ${{ secrets.SYNC_UPSTREAM_TOKEN }}
+        token: ${{ secrets.PAT_TOKEN }}
         fetch-depth: 0
 
     - name: Add upstream repository & create cherry pick branch
@@ -105,8 +103,7 @@ jobs:
           else
             echo "Cherry-picking regular commit $commit"
             git cherry-pick "$commit" || (git cherry-pick --abort && exit 1)
-          fi
-         
+          fi   
         done
 
     - name: Push changes to cherry pick branch & Create a PR
@@ -119,4 +116,5 @@ jobs:
           --title "Cherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}" \
           --body "$(echo -e "This is a auto genrated PR, Creating from odh-automation-serving\nCherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}")"
       env:
-        GITHUB_TOKEN: ${{ secrets.SYNC_UPSTREAM_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        

--- a/.github/workflows/pull_upstream_with_cherrypick.yml
+++ b/.github/workflows/pull_upstream_with_cherrypick.yml
@@ -8,20 +8,27 @@ on:
         required: true
         type: choice
         options:
-          - 'openvino_model_server'
-          - 'kserve'
-          - 'modelmesh'
+          - 'openvinotoolkit/model_server'
+          - 'kserve/kserve'
+          - 'kserve/modelmesh'
           - 'caikit-tgis-serving'
-          - 'openvino'
-          - 'vllm'
-          - 'caikit-nlp'
-          - 'caikit'
+          - 'openvinotoolkit/openvino'
+          - 'vllm-project/vllm'
+          - 'caikit/caikit-nlp'
+          - 'caikit/caikit'
           - 'odh-model-controller'
-          - 'caikit-tgis-backend'
+          - 'caikit/caikit-tgis-backend'
           - 'caikit-nlp-client'
-          - 'model-registry'
-      upstream_branch:
-        description: 'Upstream branch to pull from'
+          - 'kubeflow/model-registry'
+      Pull_and_cherrypick:
+        description: 'Select Repository to Pull_and_cherrypick'
+        required: true
+        type: choice
+        options:
+          - 'Upstream->Midstream(opendatahub-io)'
+          - 'Midstream(opendatahub-io)->Downstream(red-hat-data-services)'
+      source_branch:
+        description: 'Source branch to pull from'
         required: true
       target_branch:
         description: 'Target branch to pull into'
@@ -39,19 +46,24 @@ jobs:
   pull_and_cherry_pick:
     runs-on: ubuntu-latest
     outputs: 
-        upstream_repo: ${{ steps.set-repo.outputs.upstream_org_repo }}
-        midstream_repo: ${{ steps.set-repo.outputs.midstream_org_repo }}
-    env:
-      BASE_UPSTREAM_URL: https://github.com/opendatahub-io/
-      BASE_TARGET_URL: https://github.com/red-hat-data-services/
-      
+        target_repo: ${{ steps.set-repo.outputs.target_org_repo }}
     steps:
     - name: Set repository
       id: set-repo
       run: |
-        echo "upstream_org_repo=opendatahub-io/${{ github.event.inputs.upstream_repo }}" >> $GITHUB_OUTPUT
-        echo "midstream_org_repo=red-hat-data-services/${{ github.event.inputs.upstream_repo }}" >> $GITHUB_OUTPUT
-
+        if [[ "${{ github.event.inputs.upstream_repo }}" == *"/"* ]]; then
+          IFS='/' read -r upstreamOwner repoName <<< "${{ github.event.inputs.upstream_repo }}"
+        else
+          repoName=${{ github.event.inputs.upstream_repo }}
+          upstreamOwner=""
+        fi
+        if [ -n "$upstreamOwner" ] && [[ "${{ github.event.inputs.Pull_and_cherrypick }}" == "Upstream->Midstream(opendatahub-io)" ]]; then
+          echo "upstream_org_repo=${{ github.event.inputs.upstream_repo }}"  >> $GITHUB_OUTPUT
+          echo "target_org_repo=opendatahub-io/$repoName" >> $GITHUB_OUTPUT
+        else
+          echo "upstream_org_repo=opendatahub-io/$repoName"  >> $GITHUB_OUTPUT
+          echo "target_org_repo=red-hat-data-services/$repoName" >> $GITHUB_OUTPUT
+        fi
     - name: Configure Git & install hub
       run: |
         git config --global user.name "github-actions"
@@ -60,8 +72,8 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
-        repository: ${{ steps.set-repo.outputs.midstream_org_repo }}
-        token: ${{ secrets.PAT_TOKEN }}
+        repository: ${{ steps.set-repo.outputs.target_org_repo }}
+        token:  ${{ secrets.PAT_TOKEN }}
 
     - name: Add upstream repository & create cherry pick branch
       run: |
@@ -69,7 +81,7 @@ jobs:
           echo "Commit already exists in the target branch."
           exit 1
         fi
-        git remote add upstream ${{ env.BASE_UPSTREAM_URL }}${{ github.event.inputs.upstream_repo }}.git
+        git remote add upstream https://github.com/${{ steps.set-repo.outputs.upstream_org_repo }}.git
         git fetch upstream
         git checkout -b cherry-pick-${{ github.event.inputs.patch_commits }}
 
@@ -91,10 +103,10 @@ jobs:
       run: |
         git log -n 1 --pretty=format:"%H - %s"
         git push -f origin cherry-pick-${{ github.event.inputs.patch_commits }}
-        gh pr create --repo ${{ steps.set-repo.outputs.midstream_org_repo }} \
+        gh pr create --repo ${{ steps.set-repo.outputs.target_org_repo }} \
           --head cherry-pick-${{ github.event.inputs.patch_commits }} \
           --base ${{ github.event.inputs.target_branch }} \
           --title "Cherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}" \
           --body "$(echo -e "This is a auto genrated PR, Creating from odh-automation-serving\nCherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}")"
       env:
-        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        GITHUB_TOKEN:  ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/pull_upstream_with_cherrypick.yml
+++ b/.github/workflows/pull_upstream_with_cherrypick.yml
@@ -57,14 +57,19 @@ jobs:
           repoName=${{ github.event.inputs.upstream_repo }}
           upstreamOwner=""
         fi
+        if [[ "$repoName" == "model_server" ]]; then
+          repoName=""openvino_"$repoName"
+        fi
         if [ -n "$upstreamOwner" ] && [[ "${{ github.event.inputs.Pull_and_cherrypick }}" == "Upstream->Midstream(opendatahub-io)" ]]; then
           echo "upstream_org_repo=${{ github.event.inputs.upstream_repo }}"  >> $GITHUB_OUTPUT
-          echo "target_org_repo=opendatahub-io/$repoName" >> $GITHUB_OUTPUT
+          # echo "target_org_repo=opendatahub-io/$repoName" >> $GITHUB_OUTPUT
+          echo "target_org_repo=rpancham/$repoName" >> $GITHUB_OUTPUT
         else
           echo "upstream_org_repo=opendatahub-io/$repoName"  >> $GITHUB_OUTPUT
-          echo "target_org_repo=red-hat-data-services/$repoName" >> $GITHUB_OUTPUT
+          # echo "target_org_repo=red-hat-data-services/$repoName" >> $GITHUB_OUTPUT
+          echo "target_org_repo=rpancham/$repoName" >> $GITHUB_OUTPUT
         fi
-    - name: Configure Git & install hub
+    - name: Configure Git
       run: |
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@github.com"
@@ -73,7 +78,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ${{ steps.set-repo.outputs.target_org_repo }}
-        token:  ${{ secrets.PAT_TOKEN }}
+        token: ${{ secrets.SYNC_UPSTREAM_TOKEN }}
+        fetch-depth: 0
 
     - name: Add upstream repository & create cherry pick branch
       run: |
@@ -83,21 +89,25 @@ jobs:
         fi
         git remote add upstream https://github.com/${{ steps.set-repo.outputs.upstream_org_repo }}.git
         git fetch upstream
+        
+    - name: Create temporary branch from midstream
+      run: |
+        git checkout origin/${{ github.event.inputs.target_branch }}
         git checkout -b cherry-pick-${{ github.event.inputs.patch_commits }}
-
     - name: Cherry-pick commits
       run: |
         commits="${{ github.event.inputs.patch_commits }}"
-         IFS=',' read -ra commit_array <<< "$commits"
-          for commit in "${commit_array[@]}"; do
-            if git show --no-patch --format=%P $commit | grep -q ' '; then
-              echo "Cherry-picking merge commit $commit"
-              git cherry-pick -m 1 "$commit" || (git cherry-pick --abort && exit 1)
-            else
-              echo "Cherry-picking regular commit $commit"
-              git cherry-pick "$commit" || (git cherry-pick --abort && exit 1)
-            fi
-          done
+        IFS=',' read -ra commit_array <<< "$commits"
+        for commit in "${commit_array[@]}"; do
+          if git show --no-patch --format=%P $commit | grep -q ' '; then
+            echo "Cherry-picking merge commit $commit"
+            git cherry-pick -m 1 "$commit" || (git cherry-pick --abort && exit 1)
+          else
+            echo "Cherry-picking regular commit $commit"
+            git cherry-pick "$commit" || (git cherry-pick --abort && exit 1)
+          fi
+         
+        done
 
     - name: Push changes to cherry pick branch & Create a PR
       run: |
@@ -109,4 +119,4 @@ jobs:
           --title "Cherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}" \
           --body "$(echo -e "This is a auto genrated PR, Creating from odh-automation-serving\nCherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}")"
       env:
-        GITHUB_TOKEN:  ${{ secrets.PAT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.SYNC_UPSTREAM_TOKEN }}

--- a/.github/workflows/pull_upstream_with_cherrypick.yml
+++ b/.github/workflows/pull_upstream_with_cherrypick.yml
@@ -1,0 +1,100 @@
+name: Pull from Upstream and Cherry-pick Patches
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream_repo:
+        description: 'Select Upstream Repository'
+        required: true
+        type: choice
+        options:
+          - 'openvino_model_server'
+          - 'kserve'
+          - 'modelmesh'
+          - 'caikit-tgis-serving'
+          - 'openvino'
+          - 'vllm'
+          - 'caikit-nlp'
+          - 'caikit'
+          - 'odh-model-controller'
+          - 'caikit-tgis-backend'
+          - 'caikit-nlp-client'
+          - 'model-registry'
+      upstream_branch:
+        description: 'Upstream branch to pull from'
+        required: true
+      target_branch:
+        description: 'Target branch to pull into'
+        required: true
+      patch_commits:
+        description: 'Comma-separated list of commit SHAs to cherry-pick'
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+jobs:
+  pull_and_cherry_pick:
+    runs-on: ubuntu-latest
+    outputs: 
+        upstream_repo: ${{ steps.set-repo.outputs.upstream_org_repo }}
+        midstream_repo: ${{ steps.set-repo.outputs.midstream_org_repo }}
+    env:
+      BASE_UPSTREAM_URL: https://github.com/opendatahub-io/
+      BASE_TARGET_URL: https://github.com/red-hat-data-services/
+      
+    steps:
+    - name: Set repository
+      id: set-repo
+      run: |
+        echo "upstream_org_repo=opendatahub-io/${{ github.event.inputs.upstream_repo }}" >> $GITHUB_OUTPUT
+        echo "midstream_org_repo=red-hat-data-services/${{ github.event.inputs.upstream_repo }}" >> $GITHUB_OUTPUT
+
+    - name: Configure Git & install hub
+      run: |
+        git config --global user.name "github-actions"
+        git config --global user.email "github-actions@github.com"
+        
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ steps.set-repo.outputs.midstream_org_repo }}
+        token: ${{ secrets.PAT_TOKEN }}
+
+    - name: Add upstream repository & create cherry pick branch
+      run: |
+        if git merge-base --is-ancestor ${{ github.event.inputs.patch_commits }} origin/${{ github.event.inputs.target_branch }}; then
+          echo "Commit already exists in the target branch."
+          exit 1
+        fi
+        git remote add upstream ${{ env.BASE_UPSTREAM_URL }}${{ github.event.inputs.upstream_repo }}.git
+        git fetch upstream
+        git checkout -b cherry-pick-${{ github.event.inputs.patch_commits }}
+
+    - name: Cherry-pick commits
+      run: |
+        commits="${{ github.event.inputs.patch_commits }}"
+         IFS=',' read -ra commit_array <<< "$commits"
+          for commit in "${commit_array[@]}"; do
+            if git show --no-patch --format=%P $commit | grep -q ' '; then
+              echo "Cherry-picking merge commit $commit"
+              git cherry-pick -m 1 "$commit" || (git cherry-pick --abort && exit 1)
+            else
+              echo "Cherry-picking regular commit $commit"
+              git cherry-pick "$commit" || (git cherry-pick --abort && exit 1)
+            fi
+          done
+
+    - name: Push changes to cherry pick branch & Create a PR
+      run: |
+        git log -n 1 --pretty=format:"%H - %s"
+        git push -f origin cherry-pick-${{ github.event.inputs.patch_commits }}
+        gh pr create --repo ${{ steps.set-repo.outputs.midstream_org_repo }} \
+          --head cherry-pick-${{ github.event.inputs.patch_commits }} \
+          --base ${{ github.event.inputs.target_branch }} \
+          --title "Cherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}" \
+          --body "This is a auto generated PR\nRunning from odh-automation-serving\nCherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/pull_upstream_with_cherrypick.yml
+++ b/.github/workflows/pull_upstream_with_cherrypick.yml
@@ -95,6 +95,6 @@ jobs:
           --head cherry-pick-${{ github.event.inputs.patch_commits }} \
           --base ${{ github.event.inputs.target_branch }} \
           --title "Cherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}" \
-          --body "This is a auto generated PR\nRunning from odh-automation-serving\nCherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}"
+          --body "$(echo -e "This is a auto genrated PR, Creating from odh-automation-serving\nCherry-pick of commits ${{ github.event.inputs.patch_commits }} into ${{ github.event.inputs.target_branch }}")"
       env:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
**Pull from Upstream + Cherry-Pick a Series of Patches**
Incorporate the latest updates from the upstream repository while selectively integrating specific patches using the cherry-pick process.

We need a PAT_TOKEN of the repo odh-automation-serving to execute the workflow as normal github token doesn't work here as we are trying to run the workflow from another repository.

Issue : [RHOAIENG-8833](https://issues.redhat.com/browse/RHOAIENG-8833)