### PR TITLE
Workflow to Force-push the most recent commit unchanged to a branch t…

### DIFF
--- a/.github/workflows/force_push_to_trigger_openshift-ci_builds.yml
+++ b/.github/workflows/force_push_to_trigger_openshift-ci_builds.yml
@@ -1,0 +1,60 @@
+name: Force push most recent commit to trigger openshift-ci to rebuild images
+on:
+  workflow_dispatch:
+    inputs:
+      downstream_repo:
+        description: 'Select downstream Repository'
+        required: true
+        type: choice
+        options:
+          - 'openvino_model_server'
+          - 'kserve'
+          - 'modelmesh'
+          - 'caikit-tgis-serving'
+          - 'openvino'
+          - 'vllm'
+          - 'caikit-nlp'
+          - 'caikit'
+          - 'odh-model-controller'
+          - 'caikit-tgis-backend'
+          - 'caikit-nlp-client'
+          - 'model-registry'
+      downstream_branch:
+        description: 'downstream_branch branch to Force-push the amended commit'
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+jobs:
+  create-upstream-pr:
+    runs-on: ubuntu-latest
+    outputs: 
+        upstream_repo: ${{ steps.set-repo.outputs.upstream_org_repo }}
+        midstream_repo: ${{ steps.set-repo.outputs.downstream_org_repo }}
+    steps:
+    - name: Set repository
+      id: set-repo
+      run: |
+        echo "upstream_org_repo=opendatahub-io/${{ github.event.inputs.downstream_repo }}" >> $GITHUB_OUTPUT
+        echo "downstream_org_repo=red-hat-data-services/${{ github.event.inputs.downstream_repo }}" >> $GITHUB_OUTPUT
+    - name: Configure Git & install hub
+      run: |
+        git config --global user.name "github-actions"
+        git config --global user.email "github-actions@github.com"
+        
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ steps.set-repo.outputs.downstream_org_repo }}
+        token: ${{ secrets.PAT_TOKEN }}
+
+    - name: Amend the last commit & Force-push the amended commit
+      run: |
+        git fetch --unshallow
+        git commit --amend --no-edit
+        git push --force-with-lease origin ${{ github.event.inputs.downstream_branch }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/force_push_to_trigger_openshift-ci_builds.yml
+++ b/.github/workflows/force_push_to_trigger_openshift-ci_builds.yml
@@ -2,8 +2,8 @@ name: Force push most recent commit to trigger openshift-ci to rebuild images
 on:
   workflow_dispatch:
     inputs:
-      downstream_repo:
-        description: 'Select downstream Repository'
+      select_repo:
+        description: 'Select a Repository'
         required: true
         type: choice
         options:
@@ -19,10 +19,16 @@ on:
           - 'caikit-tgis-backend'
           - 'caikit-nlp-client'
           - 'model-registry'
-      downstream_branch:
-        description: 'downstream_branch branch to Force-push the amended commit'
+      select_branch:
+        description: 'Downstream_branch branch to Force-push the amended commit'
         required: true
-
+      select_midstream_or_downstream:
+        description: 'Select midstream_or_downstream Repository to Force push most recent commit'
+        required: true
+        type: choice
+        options:
+          - 'Midstream(opendatahub-io)'
+          - 'Downstream(red-hat-data-services)'
 permissions:
   contents: write
   packages: write
@@ -38,8 +44,11 @@ jobs:
     - name: Set repository
       id: set-repo
       run: |
-        echo "upstream_org_repo=opendatahub-io/${{ github.event.inputs.downstream_repo }}" >> $GITHUB_OUTPUT
-        echo "downstream_org_repo=red-hat-data-services/${{ github.event.inputs.downstream_repo }}" >> $GITHUB_OUTPUT
+        if [[ "${{ github.event.inputs.select_midstream_or_downstream }}" == "Midstream(opendatahub-io)" ]]; then
+          echo "target_org_repo=opendatahub-io/${{ github.event.inputs.select_repo }}" >> $GITHUB_OUTPUT       
+        else
+          echo "target_org_repo=red-hat-data-services/${{ github.event.inputs.select_repo }}" >> $GITHUB_OUTPUT        
+        fi
     - name: Configure Git & install hub
       run: |
         git config --global user.name "github-actions"
@@ -48,13 +57,13 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
-        repository: ${{ steps.set-repo.outputs.downstream_org_repo }}
+        repository: ${{ steps.set-repo.outputs.target_org_repo }}
         token: ${{ secrets.PAT_TOKEN }}
 
     - name: Amend the last commit & Force-push the amended commit
       run: |
         git fetch --unshallow
         git commit --amend --no-edit
-        git push --force-with-lease origin ${{ github.event.inputs.downstream_branch }}
+        git push --force-with-lease origin ${{ github.event.inputs.select_branch }}
       env:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
 Implement a script to force-push the most recent commit unchanged to a specified branch in order to trigger a rebuild of the OpenShift-CI image. This involves using git commit --amend followed by git push --force, which prompts OpenShift CI to initiate the rebuild process.

We need a PAT_TOKEN of the repo odh-automation-serving to execute the workflow as normal github token doesn't work here as we are trying to run the workflow from another repository.

Issue : [RHOAIENG-9159](https://issues.redhat.com/browse/RHOAIENG-9159)